### PR TITLE
Feature/downgrade to dotnet 8

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,0 +1,59 @@
+name: Develop Branch CI
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+        
+    - name: Restore dependencies
+      run: dotnet restore backend/WeatherApp.API/WeatherApp.API.csproj
+      
+    - name: Build
+      run: dotnet build backend/WeatherApp.API/WeatherApp.API.csproj --no-restore
+      
+    - name: Test
+      run: dotnet test backend/WeatherApp.API.Tests/WeatherApp.API.Tests.csproj --no-build --verbosity normal
+      
+    - name: Upload test results
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: test-results
+        path: backend/WeatherApp.API.Tests/TestResults/
+        
+  code-coverage:
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+        
+    - name: Install coverlet
+      run: dotnet tool install --global coverlet.console
+      
+    - name: Generate coverage report
+      run: dotnet test backend/WeatherApp.API.Tests/WeatherApp.API.Tests.csproj /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=./lcov.info
+      
+    - name: Upload coverage report
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: lcov.info

--- a/backend/WeatherApp.API.Tests/WeatherApp.API.Tests.csproj
+++ b/backend/WeatherApp.API.Tests/WeatherApp.API.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/backend/WeatherApp.API/WeatherApp.API.csproj
+++ b/backend/WeatherApp.API/WeatherApp.API.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
   This PR updates:
   - Changes target framework from net9.0 to net8.0 in WeatherApp.API
   - Changes target framework from net9.0 to net8.0 in WeatherApp.API.Tests
   - Updates Microsoft.AspNetCore.OpenApi package to 8.0.0